### PR TITLE
Added sendEventsBuffer method

### DIFF
--- a/android/src/main/java/com/codeard/yandexmetrica/YandexAppmetricaModule.java
+++ b/android/src/main/java/com/codeard/yandexmetrica/YandexAppmetricaModule.java
@@ -304,4 +304,9 @@ public class YandexAppmetricaModule extends ReactContextBaseJavaModule {
         }
         return array;
     }
+
+    @ReactMethod
+    public void sendEventsBuffer() {
+        YandexMetrica.sendEventsBuffer();
+    }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,5 +30,7 @@ declare module 'react-native-appmetrica-yandex' {
         public static setUserProfileAttributes(params: userProfileConfig);
 
         public static setUserProfileID(userProfileId: string);
+
+        public static sendEventsBuffer();
     }
 }

--- a/index.js
+++ b/index.js
@@ -80,4 +80,11 @@ export class YandexMetrica {
         });
         YandexAppmetrica.setUserProfileAttributes(readyAttributes);
     }
+
+    /**
+    * Sends saved events from buffer.
+    */
+    static sendEventsBuffer() {
+        YandexAppmetrica.sendEventsBuffer();
+    }
 }

--- a/ios/YandexAppmetrica.m
+++ b/ios/YandexAppmetrica.m
@@ -132,4 +132,8 @@ RCT_EXPORT_METHOD(setUserProfileAttributes:(NSDictionary *)attributes) {
     }];
 }
 
+RCT_EXPORT_METHOD(sendEventsBuffer) {
+    [YMMYandexMetrica sendEventsBuffer];
+}
+
 @end


### PR DESCRIPTION
Added missing method from native library.
**Android**
https://appmetrica.yandex.ru/docs/mobile-sdk-dg/android/ref/ru/yandex/metrica/IReporter.html#method_detail__method_sendEventsBuffer 
**iOS**
https://appmetrica.yandex.ru/docs/mobile-sdk-dg/ios/objective-c/ref/YMMYandexMetrica.html#method_detail__method_sendEventsBuffer